### PR TITLE
Add PR checklist and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+- [ ] This PR adheres to [Guidelines for GIT.md](https://github.com/solitontech/CSharp_Starter_Repo/blob/313030ea36043f4d2a6eb4258c68b31737cacc26/docs/Guidelines%20for%20GIT.md).
+- [ ] This PR was verified to comply the checks in [PRChecklist.md](https://github.com/aristovinceselvanathan/TIPS/blob/main/src/PRChecklist.md)
+- [ ] This PR changes follow C# coding conventions.
+  
+TODO: Check the above boxes with an 'x' indicating you've read and followed the [Guidelines for GIT.md](https://github.com/solitontech/CSharp_Starter_Repo/blob/313030ea36043f4d2a6eb4258c68b31737cacc26/docs/Guidelines%20for%20GIT.md), [PRChecklist.md](https://github.com/aristovinceselvanathan/TIPS/blob/main/src/PRChecklist.md) and C# coding conventions.
+
+### What does this Pull Request accomplish?
+
+TODO: Include high-level description of the changes in this pull request.
+
+### Why should this Pull Request be merged?
+
+TODO: For a bug-fix PR, justify what impact does this change bring in. Else, this can be optional and can be removed.
+
+### What testing has been done?
+
+TODO: Detail what testing has been done to ensure this submission meets requirements.

--- a/src/PRChecklist.md
+++ b/src/PRChecklist.md
@@ -1,0 +1,10 @@
+- [ ] Are all the methods decoupled with good modularity?
+- [ ] Disabled ImplicitUsings in .csproj?
+- [ ] Does the XML documentation follow the global convention of method/class documentation?
+- [ ] Are all the variables, methods & classes, files named in a meaningful & appropriate way?
+- [ ] Is the grammar correct in all the Console.WriteLine() statements?
+- [ ] Are there multiple levels of indentation? If so, can it be reduced?
+- [ ] Is the readability of the whole code base verified to be best?
+- [ ] Are all the user inputs and complex operations wrapped in such a way it doesn't break the application?
+- [ ] Is the logical implementation best to my knowledge?
+- [ ] Were all the assumptions in the development confirmed with the mentor?


### PR DESCRIPTION
- Add a PR Checklist which must be manually verified when raising a PR.
- Add a PR template, so that each PR can contain crisp and brief explanation for the changes it contains.